### PR TITLE
0.1.19

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "rai-pal"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "rai-pal"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rai-pal"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Raicuparta"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/Raicuparta/rai-pal"

--- a/frontend/components/columns-select.tsx
+++ b/frontend/components/columns-select.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@mantine/core";
+import { Button, InputLabel } from "@mantine/core";
 import { TableColumn } from "./table/table-head";
 
 type Props<TItem, TFilterOption extends string = string> = {
@@ -9,28 +9,31 @@ type Props<TItem, TFilterOption extends string = string> = {
 
 export function ColumnsSelect<TItem>(props: Props<TItem>) {
 	return (
-		<Button.Group>
-			{props.columns
-				.filter(({ hidable }) => hidable)
-				.map((column) => (
-					<Button
-						variant={
-							props.hiddenIds.find((id) => id === column.id)
-								? "default"
-								: "light"
-						}
-						key={column.id}
-						onClick={() => {
-							props.onChange(
+		<div>
+			<InputLabel>Table columns:</InputLabel>
+			<Button.Group>
+				{props.columns
+					.filter(({ hidable }) => hidable)
+					.map((column) => (
+						<Button
+							variant={
 								props.hiddenIds.find((id) => id === column.id)
-									? props.hiddenIds.filter((id) => id !== column.id)
-									: [...props.hiddenIds, column.id],
-							);
-						}}
-					>
-						{column.label || column.id}
-					</Button>
-				))}
-		</Button.Group>
+									? "default"
+									: "light"
+							}
+							key={column.id}
+							onClick={() => {
+								props.onChange(
+									props.hiddenIds.find((id) => id === column.id)
+										? props.hiddenIds.filter((id) => id !== column.id)
+										: [...props.hiddenIds, column.id],
+								);
+							}}
+						>
+							{column.label || column.id}
+						</Button>
+					))}
+			</Button.Group>
+		</div>
 	);
 }

--- a/frontend/components/installed-games/game-name.tsx
+++ b/frontend/components/installed-games/game-name.tsx
@@ -1,5 +1,6 @@
 import { InstalledGame } from "@api/bindings";
 import { Code, Flex } from "@mantine/core";
+import styles from "./installed-games.module.css";
 
 type Props = {
 	readonly game: InstalledGame;
@@ -7,10 +8,7 @@ type Props = {
 
 export function GameName(props: Props) {
 	return (
-		<Flex
-			gap="xs"
-			wrap="wrap"
-		>
+		<Flex className={styles.gameName}>
 			{props.game.name}
 			{props.game.discriminator && (
 				<Code opacity={0.5}>{props.game.discriminator}</Code>

--- a/frontend/components/installed-games/installed-games-columns.tsx
+++ b/frontend/components/installed-games/installed-games-columns.tsx
@@ -23,10 +23,13 @@ import {
 	engineFilterOptions,
 	providerFilterOptions,
 } from "../../util/common-filter-options";
+import styles from "../table/table.module.css";
 
 const thumbnailColumn: TableColumn<InstalledGame> = {
 	id: "thumbnailUrl",
-	label: "",
+	label: "Thumbnail",
+	hideLabel: true,
+	hidable: true,
 	width: 100,
 	renderCell: (game) => <ThumbnailCell url={game.thumbnailUrl} />,
 };
@@ -34,10 +37,9 @@ const thumbnailColumn: TableColumn<InstalledGame> = {
 const nameColumn: TableColumn<InstalledGame> = {
 	id: "name",
 	label: "Game",
-	width: undefined,
 	getSortValue: (game) => game.name,
 	renderCell: (game) => (
-		<Table.Td>
+		<Table.Td className={styles.nameCell}>
 			<GameName game={game} />
 		</Table.Td>
 	),
@@ -167,7 +169,12 @@ const engineColumn: TableColumn<InstalledGame, GameEngineBrand> = {
 	getFilterValue: (game) => game.executable.engine?.brand ?? "",
 	filterOptions: engineFilterOptions,
 	renderCell: ({ executable: { engine } }) => (
-		<Table.Td>
+		<Table.Td
+			// A bit annoying that I'm defining the column width in two places (see engineColumn.width),
+			// but it's to prevent this one from being squished and hiding the version number.
+			// Maybe I shouldn't be using a regular table component at all for this...
+			miw={170}
+		>
 			<Flex
 				align="center"
 				gap="xs"

--- a/frontend/components/installed-games/installed-games.module.css
+++ b/frontend/components/installed-games/installed-games.module.css
@@ -1,3 +1,8 @@
 .fileDropZone {
 	height: 15em;
 }
+
+.gameName {
+	gap: var(--mantine-spacing-xs);
+	flex-wrap: wrap;
+}

--- a/frontend/components/owned-games/owned-games-columns.tsx
+++ b/frontend/components/owned-games/owned-games-columns.tsx
@@ -4,7 +4,7 @@ import {
 	ProviderBadge,
 } from "@components/badges/color-coded-badge";
 import { TableColumn } from "@components/table/table-head";
-import { Flex, Table } from "@mantine/core";
+import { Table } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 import styles from "../table/table.module.css";
 import { ThumbnailCell } from "@components/table/thumbnail-cell";
@@ -15,7 +15,9 @@ import {
 
 const thumbnailColumn: TableColumn<OwnedGame> = {
 	id: "thumbnail",
-	label: "",
+	label: "Thumbnail",
+	hideLabel: true,
+	hidable: true,
 	width: 100,
 	renderCell: (game) => <ThumbnailCell url={game.thumbnailUrl} />,
 };
@@ -26,9 +28,7 @@ const nameColumn: TableColumn<OwnedGame> = {
 	width: undefined,
 	getSortValue: (game) => game.name,
 	renderCell: (game) => (
-		<Table.Td className={styles.leftAligned}>
-			<Flex>{game.name}</Flex>
-		</Table.Td>
+		<Table.Td className={styles.nameCell}>{game.name}</Table.Td>
 	),
 };
 

--- a/frontend/components/table/table-head.tsx
+++ b/frontend/components/table/table-head.tsx
@@ -10,6 +10,7 @@ export type TableColumn<TItem, TFilterOption extends string = string> = {
 	renderCell: (item: TItem) => JSX.Element;
 	width?: number;
 	center?: boolean;
+	hideLabel?: boolean;
 	hidable?: boolean;
 	sort?: (itemA: TItem, itemB: TItem) => number;
 	getSortValue?: (item: TItem) => unknown;
@@ -47,7 +48,7 @@ export function TableHead<TItem, TFilterOption extends string = string>(
 						w={column.width}
 					>
 						<Flex justify={column.center ? "center" : undefined}>
-							{column.label}
+							{column.hideLabel ? "" : column.label}
 							<Box
 								h={0}
 								w={0}

--- a/frontend/components/table/table.module.css
+++ b/frontend/components/table/table.module.css
@@ -3,17 +3,13 @@ div.table {
 	flex: 1;
 	user-select: none;
 
-	table {
-		table-layout: fixed;
-	}
-
 	td {
 		cursor: pointer;
-		text-align: center;
 	}
 
 	thead {
 		background: var(--background-dark);
+		white-space: nowrap;
 	}
 
 	code {
@@ -36,4 +32,9 @@ div.table {
 	background-size: 100%;
 	background-repeat: no-repeat;
 	background-color: var(--mantine-color-dark-9);
+	min-width: 50px;
+}
+
+.nameCell {
+	min-width: 10em;
 }

--- a/frontend/components/table/thumbnail-cell.tsx
+++ b/frontend/components/table/thumbnail-cell.tsx
@@ -10,7 +10,7 @@ export function ThumbnailCell(props: Props) {
 		<Table.Td
 			className={styles.thumbnail}
 			style={{
-				backgroundImage: `url(${props.url})`,
+				backgroundImage: `url(${props.url ?? "images/fallback-thumbnail.png"})`,
 			}}
 		/>
 	);

--- a/frontend/global-styles/scroll-bar.css
+++ b/frontend/global-styles/scroll-bar.css
@@ -11,6 +11,10 @@
   please remove this and test it to see if the issue is fixed.
 */
 
+*::-webkit-scrollbar-corner {
+	background: transparent;
+}
+
 *::-webkit-scrollbar {
 	width: var(--mantine-spacing-md);
 }


### PR DESCRIPTION
Prevent squishing table columns, show horizontal scroll instead.
Allow hiding thumbnails column in filter menu.
Show fallback image for thumbnails (currently for manually added games).