### PR TITLE
version 0.3.5

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3028,7 +3028,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rai-pal"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rai-pal"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Raicuparta"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/Raicuparta/rai-pal"


### PR DESCRIPTION
- Try to show error dialogs instead of failing silently if app crashes on startup.
- Handle issues with missing WebView2 dependency, often caused by "debloating" scripts. If Rai Pal detects this problem, it will now try to show helpful messages and explain what can be done to fix it.
- Add button to open the logs folder in settings tab.
- Logs have been moved to `%AppData%\raicuparta\rai-pal\data\logs`.