### PR TITLE
0.5.1

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3017,7 +3017,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rai-pal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rai-pal"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raicuparta"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/Raicuparta/rai-pal"

--- a/backend/src/mod_loaders/runnable_loader.rs
+++ b/backend/src/mod_loaders/runnable_loader.rs
@@ -90,7 +90,7 @@ fn replace_parameters(argument: &str, game: &InstalledGame) -> String {
 		Ok(game.executable.path.to_string_lossy())
 	});
 	result = replace_parameter_value(&result, RunnableParameter::GameJson, || {
-		Ok(serde_json::to_string_pretty(&game)?)
+		Ok(serde_json::to_string(&game)?)
 	});
 
 	result

--- a/backend/src/mod_loaders/runnable_loader.rs
+++ b/backend/src/mod_loaders/runnable_loader.rs
@@ -124,14 +124,6 @@ impl ModLoaderActions for RunnableLoader {
 
 		Command::new(mod_folder.join(&runnable.path))
 			.current_dir(mod_folder)
-			// .arg(&format!(
-			// 	"--attach={}",
-			// 	game.executable
-			// 		.path
-			// 		.file_name()
-			// 		.ok_or_else(|| Error::FailedToGetFileName(game.executable.path.clone()))?
-			// 		.to_string_lossy()
-			// ))
 			.args(&args)
 			.spawn()?;
 

--- a/backend/src/result.rs
+++ b/backend/src/result.rs
@@ -38,9 +38,6 @@ pub enum Error {
 	#[error("Invalid type `{0}` in binary vdf key/value pair")]
 	InvalidBinaryVdfType(u8),
 
-	#[error("Failed to get file name from path `{0}`")]
-	FailedToGetFileName(PathBuf),
-
 	#[error("Failed to find Rai Pal resources folder")]
 	ResourcesNotFound(),
 


### PR DESCRIPTION
- Remove admin prompt when launching UEVR again, this time without breaking auto-inject.
- Add generic loader for executables and scripts. Allows for easily adding scripts that can read data from the games and do stuff. I'll try to set up some documentation or examples that shows how users can take advantage of this, but you might already be able to, if you look at UEVR as an example.
- UEVR is now handled by this "runnable mod loader", so it will be redownloaded to a new location, even though there are no changes. Sorry for the inconvenience.
- Fixed error when locally-available installing/running mods while offline. That means if you've downloaded a mod once, you can install/run it on other games without having an internet connection.