### PR TITLE
0.8.0

### DIFF
--- a/frontend/components/filters/filter-button.tsx
+++ b/frontend/components/filters/filter-button.tsx
@@ -1,11 +1,12 @@
 import { FilterOption } from "@components/table/table-head";
-import { Button, Checkbox } from "@mantine/core";
+import { Button, Checkbox, Tooltip } from "@mantine/core";
 import { useCallback } from "react";
 import { UnknownFilterOption } from "./filter-select";
 import styles from "./filters.module.css";
 
 type Props<TFilterOption extends string> = {
 	readonly isHidden: boolean;
+	readonly isUnavailable: boolean;
 	readonly onClick: (value: TFilterOption | null) => void;
 	readonly filterOption: UnknownFilterOption | FilterOption<TFilterOption>;
 };
@@ -18,19 +19,26 @@ export function FilterButton<TFilterOption extends string>(
 	}, [props]);
 
 	return (
-		<Button
-			fullWidth
-			justify="start"
-			leftSection={
-				<Checkbox
-					tabIndex={-1}
-					className={styles.checkbox}
-					checked={!props.isHidden}
-				/>
-			}
-			onClick={handleClick}
+		<Tooltip
+			label="Not implemented"
+			disabled={!props.isUnavailable}
 		>
-			{props.filterOption.label || props.filterOption.value}
-		</Button>
+			<Button
+				disabled={props.isUnavailable}
+				fullWidth
+				justify="start"
+				leftSection={
+					<Checkbox
+						disabled={props.isUnavailable}
+						tabIndex={-1}
+						className={styles.checkbox}
+						checked={!props.isUnavailable && !props.isHidden}
+					/>
+				}
+				onClick={handleClick}
+			>
+				{props.filterOption.label || props.filterOption.value}
+			</Button>
+		</Tooltip>
 	);
 }

--- a/frontend/components/filters/filter-select.tsx
+++ b/frontend/components/filters/filter-select.tsx
@@ -85,6 +85,10 @@ export function FilterSelect<
 						filterOption={filterOption}
 						onClick={handleFilterClick}
 						isHidden={hiddenValues.includes(filterOption.value)}
+						isUnavailable={Boolean(
+							filterOption.value &&
+								column.unavailableValues?.includes(filterOption.value),
+						)}
 						key={filterOption.value}
 					/>
 				))}


### PR DESCRIPTION
- Add itch.io provider (requires having the itch.io app installed). Note that this does not detect games from bundles unless you've specifically added them to your library.
- Separate handling of data based on local files vs data from remote sources. This means Rai Pal will show local information more quickly, while it waits for the remote data to arrive.
- Handle more processing in parallel, to make it faster for you to see results.
- Change filters menu, to make it possible to toggle each value individually, instead of only being able to select one value at a time. This is particularly useful if you mean to hide a specific value.
- Fix a problem where window scrolling would go whacko funko mode and cause mouse events to be offset inside modals (wtf).
- Make most buttons smaller to allow for higher density in the UI.
- Fix missing thumbnails for some games in their respective game page.
- Fix broken cache for some providers.