### PR TITLE
0.12.0

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -34,7 +34,7 @@ $signature = Get-Content -Path "$msiFolder/*.sig" -Raw
 # Create json that's used by Rai Pal for checking updates.
 $updaterJson = ConvertTo-Json -InputObjec @{
   version   = "${version}"
-  notes     = "${Changelog}"
+  notes     = "${Changelog}" -replace '"', '\"'
   platforms = @{
     "windows-x86_64" = @{
       signature = "${signature}"


### PR DESCRIPTION
- Fetching mods from new version of the database, which means new UUVR versions now available, plus a new Configuration Manager mod for Unity BepInEx mods.
- Mod loaders now support passing a few extra parameters (thanks keton, and sorry for the delay).
- Use more recent version of BepInEx for IL2CPP games.
- Add new 'App Type' filter, lets you hide demos. For now, it only uses reported information from Steam, but for other providers I'm just guessing from the game name (if it ends in 'Demo', it's probably a demo).
- Delete all mod files (but not configs) from a mod's folder when that mod is updated. Helps prevent issues with conflicts when updating mods or installing mods with the same IDs.