### PR TITLE
0.13.1

### DIFF
--- a/backend/tauri-app/capabilities/main.json
+++ b/backend/tauri-app/capabilities/main.json
@@ -1,19 +1,18 @@
 {
-  "$schema": "../gen/schemas/desktop-schema.json",
-  "identifier": "main-capabilities",
-  "local": true,
-  "windows": [
-    "main"
-  ],
-  "permissions": [
-    "core:path:default",
-    "core:event:default",
-    "core:window:default",
-    "core:app:default",
-    "core:resources:default",
-    "dialog:allow-open",
-    "dialog:allow-ask",
-    "updater:allow-check",
-    "shell:default"
-  ]
+	"$schema": "../gen/schemas/desktop-schema.json",
+	"identifier": "main-capabilities",
+	"local": true,
+	"windows": ["main"],
+	"permissions": [
+		"core:path:default",
+		"core:event:default",
+		"core:window:default",
+		"core:app:default",
+		"core:resources:default",
+		"dialog:allow-open",
+		"dialog:allow-ask",
+		"updater:allow-check",
+		"shell:default",
+		"updater:default"
+	]
 }


### PR DESCRIPTION
Note: If you've manually installed a pre-release before, this update will fail. Please manually download the latest version instead.

- Games are shown as they are found. For very large libraries, this can make a huge difference, since you now start seeing some results immediately, instead of having to wait potentially minutes for the whole thing to be processed (especially for Steam games).

-  We no longer directly fetch game engine info from PCGamingWiki. That information is saved in my own database, to avoid overwhelming their servers (plus it's a lot faster for you).

- Some data is cached, so you see relevant information much more quickly when starting Rai Pal.

- List of patrons in the Thanks tab :heart: (only if they have a public profile).

- The "Demo vs Game" and "VR vs Flat" columns are now merged into a "tags" column. So you can hide demos or vr games by disabling that tag in the filter. This will probably also be used later for things like UEVR and UUVR compatibility scores.

- Definitely more suff I'm forgetting.