### PR TITLE
0.13.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Build
         id: build
         run: |
-          $output = ./publish.ps1 -Changelog "${{ github.event.pull_request.body || 'no changelog provided' }}"
+          $output = ./publish.ps1
           $version = $output | Select-Object -Last 1
           "version=$version" >> $env:GITHUB_OUTPUT
         env:
+          RAI_PAL_CHANGELOG: ${{ github.event.pull_request.body }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
           ANALYTICS_API_KEY: ${{ secrets.ANALYTICS_API_KEY }}

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,7 +1,9 @@
-param (
-  [Parameter(Mandatory = $true)]
-  [string]$Changelog
-)
+# This script reads from the following environment variables:
+#
+# - TAURI_SIGNING_PRIVATE_KEY. See https://v2.tauri.app/plugin/updater/
+# - TAURI_SIGNING_PRIVATE_KEY_PASSWORD. Password for the key above.
+# - RAI_PAL_CHANGELOG. Changelog that gets included in the update json,
+# which gets shown to users whenever they get notified of an update.
 
 function CheckEnvVar {
   param (
@@ -31,10 +33,13 @@ $version = [regex]::Match($msiName, '.+_(.+)_.+_.+').Groups[1].Value
 # Read signature from sig file.
 $signature = Get-Content -Path "$msiFolder/*.sig" -Raw
 
+# Read changelog from environment variable.
+$changelog = $env:RAI_PAL_CHANGELOG -or "Someone forgot to include a changelog."
+
 # Create json that's used by Rai Pal for checking updates.
 $updaterJson = ConvertTo-Json -InputObjec @{
   version   = "${version}"
-  notes     = "${Changelog}" -replace '"', '\"'
+  notes     = "${changelog}" -replace '"', '\"'
   platforms = @{
     "windows-x86_64" = @{
       signature = "${signature}"


### PR DESCRIPTION
- Games are shown as they are found. For very large libraries, this can make a huge difference, since you now start seeing some results immediately, instead of having to wait potentially minutes for the whole thing to be processed (especially for Steam games).
-  We no longer directly fetch game engine info from PCGamingWiki. That information is saved in my own database, to avoid overwhelming their servers (plus it's a lot faster for you).
- Some data is cached, so you see relevant information much more quickly when starting Rai Pal.
- List of patrons in the Thanks tab :heart: (only if they have a public profile).
- The "Demo vs Game" and "VR vs Flat" columns are now merged into a "tags" column. So you can hide demos or vr games by disabling that tag in the filter. This will probably also be used later for things like UEVR and UUVR compatibility scores.
- Definitely more suff I'm forgetting.