### PR TITLE
0.15.2

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3576,7 +3576,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rai-pal-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "rai-pal-proc-macros"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "quote",
  "serde",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "rai-pal-tauri"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "log",
  "rai-pal-core",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3576,7 +3576,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rai-pal-core"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "rai-pal-proc-macros"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "quote",
  "serde",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "rai-pal-tauri"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "log",
  "rai-pal-core",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,7 +3,7 @@ members = ["proc-macros", "core", "tauri-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Raicuparta"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/Raicuparta/rai-pal"


### PR DESCRIPTION
- Big rewrite, even though not much changed in terms of functionality.
- Merged owned and installed games tab into one. You can still use the filters to achieve the same result.
- Games table has a new look, organizes information a bit differently now, fewer redundant columns.
- Keep app responsive while parsing large game libraries. You should have no problem managing mods for any games while Rai Pal is still looking for games.
- Fix manual games disappearing when filtering by tags.
- Reduce false-positives for Steam owned games.