### PR TITLE
fix build script for nsis

### DIFF
--- a/publish.ps1
+++ b/publish.ps1
@@ -20,23 +20,23 @@ function CheckEnvVar {
 CheckEnvVar -Var "TAURI_SIGNING_PRIVATE_KEY"
 CheckEnvVar -Var "TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
 
-# Folder where the msi bundle will end up.
-$msiFolder = "./backend/target/release/bundle/msi"
+# Folder where the nsis bundle will end up.
+$bundleFolder = "./backend/target/release/bundle/nsis"
 
-# Delete everything in the msi folder first.
-Remove-Item $msiFolder -Force -Recurse -ErrorAction Ignore | Out-Null
+# Delete everything in the bundle folder first.
+Remove-Item $bundleFolder -Force -Recurse -ErrorAction Ignore | Out-Null
 
 npm run build
 
-# Get built msi file name.
-$msiName = (Get-ChildItem -Path $msiFolder -Filter "*.msi" | Select-Object -First 1).Name
+# Get built bundle file name.
+$exeName = (Get-ChildItem -Path $bundleFolder -Filter "*.exe" | Select-Object -First 1).Name
 
 # Extract version number from file name.
-$version = [regex]::Match($msiName, '.+_(.+)_.+_.+').Groups[1].Value
+$version = [regex]::Match($exeName, '.+_(.+)_.+_.+').Groups[1].Value
 
 # Read signature from sig file. We deleted everything in this folder before,
 # so we're pretty sure nothing other the newly created zip.sig should be found.
-$signature = Get-Content -Path "$msiFolder/*zip.sig" -Raw
+$signature = Get-Content -Path "$bundleFolder/*zip.sig" -Raw
 
 # Read changelog from environment variable.
 $changelog = $env:RAI_PAL_CHANGELOG ?? "Someone forgot to include a changelog."
@@ -66,7 +66,7 @@ $updaterJson | Set-Content -Path "$outputFolder/latest.json"
 # and remove version numbers frothe download file. This is important
 # because we want to be able to use GitHub's magic releases/latest links
 # to directly link to the latest release download.
-Copy-Item "$msiFolder/*.msi" "$outputFolder/RaiPal.msi" -Force
-Copy-Item "$msiFolder/*.zip" "$outputFolder/updater.zip" -Force
+Copy-Item "$bundleFolder/*.exe" "$outputFolder/RaiPal.exe" -Force
+Copy-Item "$bundleFolder/*.zip" "$outputFolder/updater.zip" -Force
 
 return $version


### PR DESCRIPTION
- Should hopefully improve game scanning speed for most people.
- App hangs a lot less while loading, keeps it usable while your libraries are being scanned.
- Add translations to the app text (AI-generated for now, open to contributions if you find anything weird). Language gets auto-detected, but you can pick it in the menu on the top right.
- "Tools" tab is gone in favor of a small dropdown menu.
- Refresh button only refreshes local stuff by default, to make it faster. You can optionally also re-download remote databases by clicking the dropdown on the same button.
- Fix newly added manual games not showing immediately.