### PR TITLE
0.16.1

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,7 +3,7 @@ members = ["proc-macros", "core", "tauri-app"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Raicuparta"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/Raicuparta/rai-pal"

--- a/backend/core/src/local_database.rs
+++ b/backend/core/src/local_database.rs
@@ -379,8 +379,13 @@ pub fn create() -> Result<DbMutex> {
 	let mut instant = Instant::now();
 	instant.log_next("Creating local database...");
 
+	let path = db_file_path()?;
+	if let Some(parent) = path.parent() {
+		std::fs::create_dir_all(parent)?;
+	}
+
 	let connection = rusqlite::Connection::open_with_flags(
-		db_file_path()?,
+		path,
 		OpenFlags::SQLITE_OPEN_CREATE
 			| OpenFlags::SQLITE_OPEN_READ_WRITE
 			| OpenFlags::SQLITE_OPEN_SHARED_CACHE,


### PR DESCRIPTION
- Fix startup crash for first time users.
0.16.0:
- Should hopefully improve game scanning speed for most people.
- App hangs a lot less while loading, keeps it usable while your libraries are being scanned.
- Add translations to the app text (AI-generated for now, open to contributions if you find anything weird). Language gets auto-detected, but you can pick it in the menu on the top right.
- "Tools" tab is gone in favor of a small dropdown menu.
- Refresh button only refreshes local stuff by default, to make it faster. You can optionally also re-download remote databases by clicking the dropdown on the same button.
- Fix newly added manual games not showing immediately.